### PR TITLE
Resolve textColor using view's trait collection

### DIFF
--- a/Sources/NDAvatarView/AvatarImageView.swift
+++ b/Sources/NDAvatarView/AvatarImageView.swift
@@ -152,7 +152,7 @@ open class AvatarImageView: UIImageView {
     
     
     func textAttributesFrom(data: AvatarImageViewDataSource) -> [NSAttributedString.Key: Any] {
-        var attributes: [NSAttributedString.Key: Any] = [NSAttributedString.Key.foregroundColor: configuration.textColor]
+        var attributes: [NSAttributedString.Key: Any] = [NSAttributedString.Key.foregroundColor: configuration.textColor.resolvedColor(with: traitCollection)]
         let fontSize = bounds.size.width * configuration.textSizeFactor
         
         if let fontName = configuration.fontName {


### PR DESCRIPTION
`AvatarImageView` renders text via a call to `NSString.draw(in:withAttributes:)`. If the text color is a dynamic color, `NSString.draw` resolves the color based on the system user interface style, so if `overrideUserInterfaceStyle` does not match the system setting, the resolved color will not match the `AvatarImageView`'s trait collection. To fix this, this commit resolves the text color manually based on the `AvatarImageView`'s trait collection.